### PR TITLE
Adds ENABLE_AUTO_CERTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ docker run \
   freemountain/nginx-ssl-proxy
 ```
 
+You can do this step during the proxy container launch setting environment variable ```ENABLE_AUTO_CERTS=true```.
+
 #### Use existing certificates
 You can build a custom image containing your certfiles. Then use this image to create your data Container. (not tested).
 

--- a/start.sh
+++ b/start.sh
@@ -16,6 +16,9 @@
 if [ -n "${ENABLE_SSL+1}" ] && [ "${ENABLE_SSL,,}" = "true" ]; then
   echo "Enabling SSL..."
   cp /usr/src/proxy_ssl.conf /etc/nginx/conf.d/proxy.conf
+  if [ -n "${ENABLE_AUTO_CERTS+1}" ] && [ "${ENABLE_AUTO_CERTS,,}" = "true" ]; then
+    . ./init.sh
+  fi
 else
   # No SSL
   cp /usr/src/proxy_nossl.conf /etc/nginx/conf.d/proxy.conf


### PR DESCRIPTION
Using this environment variable you can autogenerate the SSL certificates if set to true. It will use `init.sh`, so it will check if it exists before creating it.
